### PR TITLE
Implements read receipt forwarding to third party network

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-puppet-bridge",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "facilitates writing a certain kind of matrix bridge",
   "main": "index.js",
   "scripts": {

--- a/src/base.js
+++ b/src/base.js
@@ -159,6 +159,16 @@ class Base {
   }
 
   /**
+   * Implement how a read receipt is sent over the third party network
+   *
+   * @param {string} _thirdPartyRoomId
+   * @returns {Promise}
+   */
+  sendReadReceiptAsPuppetToThirdPartyRoomWithId(_thirdPartyRoomId) {
+    return Promise.reject(new Error('please implement sendReadReceiptAsPuppetToThirdPartyRoomWithId'));
+  }
+
+  /**
    * Return a postfix for the status room name.
    * It should be fairly unique so that it's unlikely to clash with a legitmate user.
    * (Let's hope nobody likes the name 'puppetStatusRoom')
@@ -193,6 +203,8 @@ class Base {
     this.deduplicationTagRegex = new RegExp(this.deduplicationTagPattern);
     this.bridge = bridge || this.setupBridge(config);
     info('initialized');
+
+    this.puppet.setApp(this)
   }
 
   /**
@@ -514,6 +526,9 @@ class Base {
           return matrixRoomId;
         }
       });
+    }).then(matrixRoomId => {
+      this.puppet.saveThirdPartyRoomId(matrixRoomId, thirdPartyRoomId);
+      return matrixRoomId;
     });
   }
 


### PR DESCRIPTION
We don't get the read receipts from the bridge app, but we get them from the puppet client. I'm using that to forward them to the third party network.

In order to be able to determine if the read receipt needs to be forwarded and to actually forward it, the puppet client needs to know the rooms list and to have a pointer to the app.