### PR TITLE
Ghost create room

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -515,9 +515,11 @@ class Base {
     const botClient = botIntent.getClient();
     const puppetUserId = puppetClient.credentials.userId;
 
+    let creatorIntent;
+
     const grantPuppetMaxPowerLevel = (room_id) => {
       info("ensuring puppet user has full power over this room");
-      return botIntent.setPowerLevel(room_id, puppetUserId, 100).then(()=>{
+      return creatorIntent.setPowerLevel(room_id, puppetUserId, 100).then(()=>{
         info('granted puppet client admin status on the protocol status room');
       }).catch((err)=>{
         warn(err);
@@ -540,8 +542,10 @@ class Base {
           name, topic, room_alias_name: roomAliasName
         };
         if ( ghostIntent ) {
+          creatorIntent = ghostIntent;
           return ghostIntent.createRoom({ options, createAsClient: false });
         } else {
+          creatorIntent = botIntent;
           return botIntent.createRoom({ options, createAsClient: true });
         }
       }).then(({room_id}) => {


### PR DESCRIPTION
in 1.15.1 we changed things from the matrix puppet being the one
creating the room to the AS bot being the one, because if the room
alias regex registration was set, only AS bots can manipulate it

this is a problem, however, because when the puppet would create the
room it would appear as a "direct message" which made it seamless
with respect to the ghost users appearance in the protocol room

this commit tries to fix that by making the ghost user be the one
creating the room.