### PR TITLE
remove everything after semicolumn in mime-type

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -854,7 +854,7 @@ class Base {
         return download.getBufferAndType(avatarUrl).then(({buffer, type})=> {
           let opts = {
             name: path.basename(avatarUrl),
-            type,
+            type.split(';')[0],
             rawResponse: false
           };
           return client.uploadContent(buffer, opts);


### PR DESCRIPTION
It appears that skype replies for their avatars as mime-type `image/jpeg; ver=1.0` however synapse sees as valid image mimetypes for the thumbnails apparently only stuff like `image/jpeg`.
I am not sure who is at fault, e.i. how standard it is to have mimetypes with arguments, so i just submitted the fix here