### PR TITLE
Follow redirects in downloadGetStream

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@ const urlParse = require('url').parse;
 const fs = require('fs');
 const tmp = require('tmp');
 
-const downloadGetStream = url => needle.get(url);
+const downloadGetStream = url => needle.get(url, {follow: 10});
 
 const downloadGetBuffer = url => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
This fixes bugs that arise when a third-party gives us an avatar URL
  that looks valid but involves one or more redirects to get to the real
  resource, e.g. Slack's default avatars