### PR TITLE
Use ghostIntent to get matrix profile

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -845,7 +845,7 @@ class Base {
     const { info }  = debug(this.setGhostAvatar.name);
     const client = ghostIntent.getClient();
 
-    return client.getProfileInfo(client.credentials.userId, 'avatar_url').then(({avatar_url})=>{
+    return ghostIntent.getProfileInfo(client.credentials.userId, 'avatar_url').then(({avatar_url})=>{
       if (avatar_url) {
         info('refusing to overwrite existing avatar');
         return null;


### PR DESCRIPTION
This works around a race in `getIntentFromThirdPartySenderId()` when the
`setGhostAvatar()` promise is called before
`ghostIntent.setDisplayName()` is resolved.

The `ghostIntent.getProfileInfo()` method ensures that the matrix user
exists before returning the profile.

This fixes sporadic `[M_UNKNOWN: No row found]` errors on messages from
a new user.

```
Error in handleThirdPartyRoomMessage { [M_UNKNOWN: No row found]
  errcode: 'M_UNKNOWN',
  name: 'M_UNKNOWN',
  message: 'No row found',
  data: { errcode: 'M_UNKNOWN', error: 'No row found' },
  httpStatus: 404 } { roomId: '<redacted>',
  senderId: '<redacted>',
  senderName: '<redacted>',
  avatarUrl: 'https://example.org/avatar',
  text: 'example text' }
```

Fixes: 9846965 ("skip avatar routines unless ghost has no avatar")