### PR TITLE
Fix empty filename

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -822,15 +822,15 @@ class Base {
           size: data.content.info.size,
         }, data);
       } else if (msgtype === 'm.file') {
-	logger.info("file upload from riot");
+        logger.info("file upload from riot");
 
-	let url = this.puppet.getClient().mxcUrlToHttp(data.content.url);
-	promise = () => this.sendFileMessageAsPuppetToThirdPartyRoomWithId(thirdPartyRoomId, {
-	  url, text: msg,
-	  mimetype: data.content.info.mimetype,
-	  size: data.content.info.size,
-	  filename: data.content.filename,
-	}, data);
+        let url = this.puppet.getClient().mxcUrlToHttp(data.content.url);
+        promise = () => this.sendFileMessageAsPuppetToThirdPartyRoomWithId(thirdPartyRoomId, {
+          url, text: msg,
+          mimetype: data.content.info.mimetype,
+          size: data.content.info.size,
+          filename: data.content.filename || body || '',
+        }, data);
       } else {
         promise = () => Promise.reject(new Error('dont know how to handle this msgtype', msgtype));
       }


### PR DESCRIPTION
[pick][1] from matrix-puppet-slack.
it also related that repo's [issue][2]
`data.content.filename` still exists in [the spec][3].
but I don't know a reason, this field is `undefined` in my test.

[1]: https://github.com/matrix-hacks/matrix-puppet-slack/blob/355bb4e/app.js#L388-L390
[2]: https://github.com/matrix-hacks/matrix-puppet-slack/issues/65
[3]: https://github.com/matrix-org/matrix-doc/blob/f1f32d3/event-schemas/schema/m.room.message%23m.file#L8-L13