### PR TITLE
Super simple fix to handle m.notice messages

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -802,7 +802,7 @@ class Base {
     } else {
       msg = this.tagMatrixMessage(body);
 
-      if (msgtype === 'm.text' || msgtype == 'm.notice') {
+      if (msgtype === 'm.text' || msgtype === 'm.notice') {
         if (this.handleMatrixUserBangCommand) {
           const bc = bangCommand(body);
           if (bc) return this.handleMatrixUserBangCommand(bc, data);

--- a/src/base.js
+++ b/src/base.js
@@ -802,7 +802,7 @@ class Base {
     } else {
       msg = this.tagMatrixMessage(body);
 
-      if (msgtype === 'm.text') {
+      if (msgtype === 'm.text' || msgtype == 'm.notice') {
         if (this.handleMatrixUserBangCommand) {
           const bc = bangCommand(body);
           if (bc) return this.handleMatrixUserBangCommand(bc, data);


### PR DESCRIPTION
This is a 1/2 line fix to handle `m.notice` messages that are primarily used by bots and should be treated the same as `m.text` messages.