### PR TITLE
Handle m.notice messages

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -802,7 +802,7 @@ class Base {
     } else {
       msg = this.tagMatrixMessage(body);
 
-      if (msgtype === 'm.text' || msgtype == 'm.notice') {
+      if (msgtype === 'm.text' || msgtype === 'm.notice') {
         if (this.handleMatrixUserBangCommand) {
           const bc = bangCommand(body);
           if (bc) return this.handleMatrixUserBangCommand(bc, data);

--- a/src/base.js
+++ b/src/base.js
@@ -802,7 +802,7 @@ class Base {
     } else {
       msg = this.tagMatrixMessage(body);
 
-      if (msgtype === 'm.text') {
+      if (msgtype === 'm.text' || msgtype == 'm.notice') {
         if (this.handleMatrixUserBangCommand) {
           const bc = bangCommand(body);
           if (bc) return this.handleMatrixUserBangCommand(bc, data);


### PR DESCRIPTION
Messages with `msgtype` of `m.notice` should be handled just like `m.text`.