### PR TITLE
Set rooms invite only

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -576,6 +576,21 @@ class Base {
         }
       });
     }).then(matrixRoomId => {
+      info("setting room as invite-only", matrixRoomId);
+      return puppetClient.sendStateEvent(matrixRoomId, "m.room.join_rules", {"join_rule": "invite"}).then(() =>{
+        info("succeeded in setting room as invite-only using puppet client. Room:", matrixRoomId);
+        return matrixRoomId;
+      }, (err) => {
+        info("Since setting join rules with puppet client failed, now trying with bot client");
+        return botIntent.sendStateEvent(matrixRoomId, "m.room.join_rules", "", {"join_rule": "invite"}).then(()=>{
+          info("succeeded in setting room as invite-only using bot client. Room:", matrixRoomId);
+          return matrixRoomId;
+        }, (err) => {
+          warn("Both puppet and bot client invite only settings failed :( Error:", err.message);
+          return matrixRoomId;
+        });
+      });
+    }).then(matrixRoomId => {
       this.puppet.saveThirdPartyRoomId(matrixRoomId, thirdPartyRoomId);
       return matrixRoomId;
     });


### PR DESCRIPTION
@AndrewJDR , tested this today, by creating a new Slack user ("installing" Simple Poll, which causes a new user to join my Slackbot 1:1 room), then verifying that the room as set invite-only, then kicking the bot and uninstalling the app, then doing it again to see if the bot was able to join. It was!

![screenshot_2019-02-23 riot](https://user-images.githubusercontent.com/13843293/53288500-a7ad3a00-3780-11e9-8a82-6460f07ee84d.png)

Gonna go ahead and create a PR myself to merge this. Thanks a ton; this was a big deficiency.
