### PR TITLE
Mark 3rd-party direct chats as direct rooms in Matrix

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -563,12 +563,13 @@ class Base {
       info("the room doesn't exist. we need to create it for the first time");
       return Promise.resolve(this.getThirdPartyRoomDataById(thirdPartyRoomId)).then(thirdPartyRoomData => {
         info("got 3p room data", thirdPartyRoomData);
-        const { name, topic } = thirdPartyRoomData;
+        const { name, topic, is_direct } = thirdPartyRoomData;
         info("creating room !!!!", ">>>>"+roomAliasName+"<<<<", name, topic);
         return botIntent.createRoom({
           createAsClient: true, // bot won't auto-join the room in this case
           options: {
-            name, topic, room_alias_name: roomAliasName
+            name, topic, is_direct,
+            invite: [puppetUserId], room_alias_name: roomAliasName
           }
         }).then(({room_id}) => {
           info("room created", room_id, roomAliasName);

--- a/src/base.js
+++ b/src/base.js
@@ -273,20 +273,6 @@ class Base {
   }
 
   /**
-   * Returns a promise
-   */
-  async _joinPuppetClientToRoom(matrixRoomId) {
-    const botIntent = this.getIntentFromApplicationServerBot();
-    const botClient = botIntent.getClient();
-
-    const puppetClient = this.puppet.getClient();
-    const puppetUserId = puppetClient.credentials.userId;
-
-    await botClient.invite(matrixRoomId, puppetUserId);
-    await puppetClient.joinRoom(matrixRoomId);
-  }
-
-  /**
    * Async call to get the status room ID
    *
    * @params {_roomAliasLocalPart} Optional, the room alias local part
@@ -578,7 +564,7 @@ class Base {
       });
     }).then(matrixRoomId => {
       info("making puppet join room", matrixRoomId);
-      return this._joinPuppetClientToRoom(matrixRoomId).then(()=>{
+      return puppetClient.joinRoom(matrixRoomId).then(()=>{
         info("returning room id after join room attempt", matrixRoomId);
         return grantPuppetMaxPowerLevel(matrixRoomId);
       }, (err) => {

--- a/src/base.js
+++ b/src/base.js
@@ -677,11 +677,10 @@ class Base {
         .then((ghostIntent) => {
           return this.getStatusRoomId()
             .then(statusRoomId => ghostIntent.join(statusRoomId))
-            .then(() => puppetClient.invite(roomId, ghostIntent.client.credentials.userId))
-              // This will error badly if the ghost is already in the room, so we catch it. Is it easy to check if ghost is already in the room?
-              // FIXME: An empty catch feels pretty evil, but I don't know the language or codebase well enough to do better
-              .catch()
-            .then(() => ghostIntent.join(roomId))  // Interestingly. this doesn't error if the ghost is already in the room
+            .then(() => ghostIntent.join(roomId)).catch(
+              puppetClient.invite(roomId, ghostIntent.client.credentials.userId)
+              .then(() => ghostIntent.join(roomId))
+            )
             .then(() => ghostIntent.getClient());
         });
     }


### PR DESCRIPTION
I couldn't find a more simplistic way to do this without reverting #48 and moving that invite call to happen during initial room creation, which probably simplifies #48 as well anyway. Also included the no_join_bot_testing branch, not sure it was needed, but I ended up doing so anyway after I also made a fix for that branch at the same time.

This also requires a change in the protocol specific puppet library which I have done on the matrix-puppet-facebook library (matrix-hacks/matrix-puppet-facebook#52) however merging this in won't break libraries that don't yet support it.

This is intended to solve matrix-hacks/matrix-puppet-facebook#4