### PR TITLE
add sticker handling

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -969,6 +969,12 @@ class Base {
   handleMatrixEvent(req, _context) {
     const { info, warn } = debug(this.handleMatrixEvent.name);
     const data = req.getData();
+    if(data.type === 'm.sticker') {
+        info('incoming sticker.');
+        info('converting sticker to image.');
+        data['content']['msgtype'] = 'm.image';
+        data['type'] = 'm.room.message';
+    }
     if (data.type === 'm.room.message') {
       info('incoming message. data:', data);
       return this.handleMatrixMessageEvent(data);


### PR DESCRIPTION
With this modifications Riot (or hopefully other Matrix stickers)
are converted to regular image messages.
In case a bridge already handles images, stickers will work with it as well.