### PR TITLE
Fix the usage of retrieved profile pics for fb users in matrix-puppet-facebook

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -1087,8 +1087,9 @@ class Base {
     info('fetching avatar from', avatar);
     let buffer, mimetype;
     if(typeof avatar == "string") {
-      buffer = await download.getBufferAndType(avatar).buffer;
-      mimetype = await download.getBufferAndType(avatar).type;
+      let downloadedData = await download.getBufferAndType(avatar);
+      buffer = downloadedData.buffer;
+      mimetype = downloadedData.type;
     } else {
       buffer = avatar.buffer;
       mimetype = avatar.type;


### PR DESCRIPTION
As I am trying to work on https://github.com/matrix-hacks/matrix-puppet-facebook/issues/2, I noticed I got a lot of errors when trying to read in fb users. By applying this small fix I could mitigate this and avatars appeared for all fb users, which is a nice functionality.