### PR TITLE
Fix aliases

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -474,7 +474,8 @@ class Base {
       return null;
     }
     info('reducing array of alases to a 3prid');
-    return room.getAliases().reduce((result, alias) => {
+    const aliases = [room.getCanonicalAlias()].concat(room.getAliases());
+    return aliases.reduce((result, alias) => {
       const localpart = alias.replace(':'+this.domain, '');
       const matches = localpart.match(patt);
       return matches ? matches[1] : result;


### PR DESCRIPTION
This resolves issues with sending messages like this:
```
Error in handleMatrixEvent { Error: could not determine third party room id!
    at App._handleMatrixMessageEvent (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-puppet-bridge/src/base.js:1034:13)
    at App.handleMatrixMessageEvent (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-puppet-bridge/src/base.js:1015:25)
    at App.handleMatrixEvent (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-puppet-bridge/src/base.js:1007:19)
    at Bridge._onConsume (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-appservice-bridge/lib/bridge.js:871:26)
    at tryCatcher (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-appservice-bridge/node_modules/bluebird/js/main/util.js:26:23)
    at Promise.successAdapter (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-appservice-bridge/node_modules/bluebird/js/main/nodeify.js:23:30)
    at Promise._settlePromiseAt (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-appservice-bridge/node_modules/bluebird/js/main/promise.js:582:21)
    at Promise._settlePromises (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-appservice-bridge/node_modules/bluebird/js/main/promise.js:700:14)
    at Async._drainQueue (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-appservice-bridge/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-appservice-bridge/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues (/home/niklas/git/matrix-puppet-signal/node_modules/matrix-appservice-bridge/node_modules/bluebird/js/main/async.js:15:14)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
```

Looks like matrix server changed the api. 